### PR TITLE
Add support for multiple Redis databases

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "HummingbirdJobsRedis", targets: ["HummingbirdJobsRedis"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "1.0.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "1.6.0"),
         .package(url: "https://github.com/swift-server/RediStack.git", from: "1.4.0"),
     ],
     targets: [

--- a/Sources/HummingbirdJobsRedis/Configuration.swift
+++ b/Sources/HummingbirdJobsRedis/Configuration.swift
@@ -17,7 +17,7 @@ import RediStack
 
 extension HBRedisJobQueue {
     /// Redis Job queue configuration
-    public struct Configuration {
+    public struct Configuration: Sendable {
         let queueKey: RedisKey
         let processingQueueKey: RedisKey
         let rerunProcessing: Bool
@@ -35,3 +35,5 @@ extension HBRedisJobQueue {
         }
     }
 }
+
+extension RedisKey: @unchecked Sendable {}

--- a/Sources/HummingbirdJobsRedis/RedisJobQueue.swift
+++ b/Sources/HummingbirdJobsRedis/RedisJobQueue.swift
@@ -40,8 +40,17 @@ public final class HBRedisJobQueue: HBJobQueue {
 
     /// Initialize redis job queue
     /// - Parameters:
-    ///   - application: Application
-    ///   - configuration: Configuration
+    ///   - application: application to get redis setup from
+    ///   - configuration: configuration
+    public init(_ application: HBApplication, configuration: Configuration) {
+        self.redisConnectionPoolGroup = application.redis
+        self.configuration = configuration
+    }
+
+    /// Initialize redis job queue
+    /// - Parameters:
+    ///   - redisConnectionPoolGroup: Redis connection pool group
+    ///   - configuration: configuration
     public init(_ redisConnectionPoolGroup: RedisConnectionPoolGroup, configuration: Configuration) {
         self.redisConnectionPoolGroup = redisConnectionPoolGroup
         self.configuration = configuration

--- a/Sources/HummingbirdJobsRedis/RedisJobQueue.swift
+++ b/Sources/HummingbirdJobsRedis/RedisJobQueue.swift
@@ -19,7 +19,7 @@ import NIOCore
 import RediStack
 
 /// Redis implementation of job queues
-public class HBRedisJobQueue: HBJobQueue {
+public final class HBRedisJobQueue: HBJobQueue {
     public enum RedisQueueError: Error, CustomStringConvertible {
         case unexpectedRedisKeyType
         case jobMissing(JobIdentifier)
@@ -34,7 +34,7 @@ public class HBRedisJobQueue: HBJobQueue {
         }
     }
 
-    let application: HBApplication
+    let redisConnectionPoolGroup: RedisConnectionPoolGroup
     let configuration: Configuration
     public var pollTime: TimeAmount { self.configuration.pollTime }
 
@@ -42,8 +42,8 @@ public class HBRedisJobQueue: HBJobQueue {
     /// - Parameters:
     ///   - application: Application
     ///   - configuration: Configuration
-    public init(_ application: HBApplication, configuration: Configuration) {
-        self.application = application
+    public init(_ redisConnectionPoolGroup: RedisConnectionPoolGroup, configuration: Configuration) {
+        self.redisConnectionPoolGroup = redisConnectionPoolGroup
         self.configuration = configuration
     }
 
@@ -66,7 +66,7 @@ public class HBRedisJobQueue: HBJobQueue {
     ///   - eventLoop: eventLoop to do work on
     /// - Returns: Queued job
     public func push(_ job: HBJob, on eventLoop: EventLoop) -> EventLoopFuture<HBQueuedJob> {
-        let pool = self.application.redis.pool(for: eventLoop)
+        let pool = self.redisConnectionPoolGroup.pool(for: eventLoop)
         let queuedJob = HBQueuedJob(job)
         return self.set(jobId: queuedJob.id, job: queuedJob.job, pool: pool)
             .flatMap {
@@ -81,7 +81,7 @@ public class HBRedisJobQueue: HBJobQueue {
     /// - Parameter eventLoop: eventLoop to do work on
     /// - Returns: queued job
     public func pop(on eventLoop: EventLoop) -> EventLoopFuture<HBQueuedJob?> {
-        let pool = self.application.redis.pool(for: eventLoop)
+        let pool = self.redisConnectionPoolGroup.pool(for: eventLoop)
         return pool.rpoplpush(from: self.configuration.queueKey, to: self.configuration.processingQueueKey)
             .flatMap { key -> EventLoopFuture<HBQueuedJob?> in
                 if key.isNull {
@@ -106,7 +106,7 @@ public class HBRedisJobQueue: HBJobQueue {
     ///   - jobId: Job id
     ///   - eventLoop: eventLoop to do work on
     public func finished(jobId: JobIdentifier, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
-        let pool = self.application.redis.pool(for: eventLoop)
+        let pool = self.redisConnectionPoolGroup.pool(for: eventLoop)
         return pool.lrem(jobId.description, from: self.configuration.processingQueueKey, count: 0)
             .flatMap { _ in
                 return self.delete(jobId: jobId, pool: pool)
@@ -119,7 +119,7 @@ public class HBRedisJobQueue: HBJobQueue {
     /// last time queues were processed so needs to be re run
     public func rerunProcessing(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
         let promise = eventLoop.makePromise(of: Void.self)
-        let pool = self.application.redis.pool(for: eventLoop)
+        let pool = self.redisConnectionPoolGroup.pool(for: eventLoop)
         func _moveOneEntry() {
             pool.rpoplpush(from: self.configuration.processingQueueKey, to: self.configuration.queueKey)
                 .whenComplete { result in
@@ -154,8 +154,25 @@ public class HBRedisJobQueue: HBJobQueue {
 
 extension HBJobQueueFactory {
     /// In memory driver for persist system
-    public static func redis(configuration: HBRedisJobQueue.Configuration = .init()) -> HBJobQueueFactory {
-        .init(create: { app in HBRedisJobQueue(app, configuration: configuration) })
+    public static func redis(
+        configuration: HBRedisJobQueue.Configuration = .init()
+    ) -> HBJobQueueFactory {
+        .init { app in
+            return HBRedisJobQueue(app.redis, configuration: configuration)
+        }
+    }
+
+    /// In memory driver for persist system
+    public static func redis(
+        id: RedisConnectionPoolGroupArray.Identifier,
+        configuration: HBRedisJobQueue.Configuration = .init()
+    ) -> HBJobQueueFactory {
+        .init { app in
+            guard let connectionPool = app.redisConnectionPools[id] else {
+                preconditionFailure("Redis Connection Pool Group id: \(id) does not exist")
+            }
+            return HBRedisJobQueue(connectionPool, configuration: configuration)
+        }
     }
 }
 

--- a/Sources/HummingbirdJobsRedis/RedisJobQueue.swift
+++ b/Sources/HummingbirdJobsRedis/RedisJobQueue.swift
@@ -153,7 +153,7 @@ public final class HBRedisJobQueue: HBJobQueue {
 }
 
 extension HBJobQueueFactory {
-    /// In memory driver for persist system
+    /// Redis Job queue driver
     public static func redis(
         configuration: HBRedisJobQueue.Configuration = .init()
     ) -> HBJobQueueFactory {
@@ -162,9 +162,9 @@ extension HBJobQueueFactory {
         }
     }
 
-    /// In memory driver for persist system
+    /// Redis Job queue drive
     public static func redis(
-        id: RedisConnectionPoolGroupArray.Identifier,
+        id: RedisConnectionPoolGroupIdentifier,
         configuration: HBRedisJobQueue.Configuration = .init()
     ) -> HBJobQueueFactory {
         .init { app in

--- a/Sources/HummingbirdRedis/Application+Redis.swift
+++ b/Sources/HummingbirdRedis/Application+Redis.swift
@@ -22,19 +22,42 @@ extension HBApplication {
         self.extensions.get(\.redisConnectionPools, error: "To use Redis you need to set it up first. Please call HBApplication.addRedis()")
     }
 
-    public func redis(_ id: RedisConnectionPoolGroupArray.Identifier) -> RedisConnectionPoolGroup? {
+    public func redis(id: RedisConnectionPoolGroupArray.Identifier) -> RedisConnectionPoolGroup? {
         self.redisConnectionPools[id]
     }
 
     /// Add Redis to HBApplication
     /// - Parameter configuration: Redis configuration
     public func addRedis(configuration: HBRedisConfiguration) {
+        guard !self.extensions.exists(\.redisConnectionPools) else {
+            preconditionFailure("Redis has already been added to the application")
+        }
         self.extensions.set(\.redisConnectionPools, value: .init(
             configuration: configuration,
             eventLoopGroup: self.eventLoopGroup,
             logger: self.logger
         )) { redisConnectionPools in
             try redisConnectionPools.closePools().wait()
+        }
+    }
+
+    /// Add Redis to HBApplication
+    /// - Parameter configuration: Redis configuration
+    public func addRedis(id: RedisConnectionPoolGroupArray.Identifier, configuration: HBRedisConfiguration) {
+        if !self.extensions.exists(\.redisConnectionPools) {
+            self.extensions.set(\.redisConnectionPools, value: .init(
+                id: id,
+                configuration: configuration,
+                eventLoopGroup: self.eventLoopGroup,
+                logger: self.logger
+            )) { redisConnectionPools in
+                try redisConnectionPools.closePools().wait()
+            }
+        } else {
+            guard self.redisConnectionPools[id] == nil else {
+                preconditionFailure("Redis with id: '\(id)' has already been added to the application")
+            }
+            self.redisConnectionPools.addConnectionPool(id: id, configuration: configuration, logger: self.logger)
         }
     }
 }

--- a/Sources/HummingbirdRedis/Application+Redis.swift
+++ b/Sources/HummingbirdRedis/Application+Redis.swift
@@ -15,18 +15,26 @@
 import Hummingbird
 extension HBApplication {
     public var redis: RedisConnectionPoolGroup {
-        self.extensions.get(\.redis)
+        self.redisConnectionPools.default
+    }
+
+    public var redisConnectionPools: RedisConnectionPoolGroupArray {
+        self.extensions.get(\.redisConnectionPools, error: "To use Redis you need to set it up first. Please call HBApplication.addRedis()")
+    }
+
+    public func redis(_ id: RedisConnectionPoolGroupArray.Identifier) -> RedisConnectionPoolGroup? {
+        self.redisConnectionPools[id]
     }
 
     /// Add Redis to HBApplication
     /// - Parameter configuration: Redis configuration
     public func addRedis(configuration: HBRedisConfiguration) {
-        self.extensions.set(\.redis, value: .init(
+        self.extensions.set(\.redisConnectionPools, value: .init(
             configuration: configuration,
             eventLoopGroup: self.eventLoopGroup,
             logger: self.logger
-        )) { redis in
-            try redis.closePools().wait()
+        )) { redisConnectionPools in
+            try redisConnectionPools.closePools().wait()
         }
     }
 }

--- a/Sources/HummingbirdRedis/Application+Redis.swift
+++ b/Sources/HummingbirdRedis/Application+Redis.swift
@@ -22,7 +22,7 @@ extension HBApplication {
         self.extensions.get(\.redisConnectionPools, error: "To use Redis you need to set it up first. Please call HBApplication.addRedis()")
     }
 
-    public func redis(id: RedisConnectionPoolGroupArray.Identifier) -> RedisConnectionPoolGroup? {
+    public func redis(id: RedisConnectionPoolGroupIdentifier) -> RedisConnectionPoolGroup? {
         self.redisConnectionPools[id]
     }
 
@@ -43,7 +43,7 @@ extension HBApplication {
 
     /// Add Redis to HBApplication
     /// - Parameter configuration: Redis configuration
-    public func addRedis(id: RedisConnectionPoolGroupArray.Identifier, configuration: HBRedisConfiguration) {
+    public func addRedis(id: RedisConnectionPoolGroupIdentifier, configuration: HBRedisConfiguration) {
         if !self.extensions.exists(\.redisConnectionPools) {
             self.extensions.set(\.redisConnectionPools, value: .init(
                 id: id,

--- a/Sources/HummingbirdRedis/Persist+Redis.swift
+++ b/Sources/HummingbirdRedis/Persist+Redis.swift
@@ -70,7 +70,7 @@ extension HBPersistDriverFactory {
     }
 
     /// Redis driver for persist system
-    public func redis(id: RedisConnectionPoolGroupIdentifier) -> HBPersistDriverFactory {
+    public static func redis(id: RedisConnectionPoolGroupIdentifier) -> HBPersistDriverFactory {
         .init { app in
             guard let redisConnectionPoolGroup = app.redisConnectionPools[id] else {
                 preconditionFailure("Redis Connection Pool Group id: \(id) does not exist")

--- a/Sources/HummingbirdRedis/Persist+Redis.swift
+++ b/Sources/HummingbirdRedis/Persist+Redis.swift
@@ -70,7 +70,7 @@ extension HBPersistDriverFactory {
     }
 
     /// Redis driver for persist system
-    public func redis(id: RedisConnectionPoolGroupArray.Identifier) -> HBPersistDriverFactory {
+    public func redis(id: RedisConnectionPoolGroupIdentifier) -> HBPersistDriverFactory {
         .init { app in
             guard let redisConnectionPoolGroup = app.redisConnectionPools[id] else {
                 preconditionFailure("Redis Connection Pool Group id: \(id) does not exist")

--- a/Sources/HummingbirdRedis/Persist+Redis.swift
+++ b/Sources/HummingbirdRedis/Persist+Redis.swift
@@ -17,18 +17,18 @@ import Hummingbird
 import RediStack
 
 /// Redis driver for persist system for storing persistent cross request key/value pairs
-struct HBRedisPersistDriver: HBPersistDriver {
-    init(application: HBApplication) {
-        precondition(
-            application.extensions.exists(\HBApplication.redis),
-            "Cannot use Redis driver without having setup Redis. Please call HBApplication.addRedis()"
-        )
+public struct HBRedisPersistDriver: HBPersistDriver {
+    let redisConnectionPoolGroup: RedisConnectionPoolGroup
+
+    public init(redisConnectionPoolGroup: RedisConnectionPoolGroup) {
+        self.redisConnectionPoolGroup = redisConnectionPoolGroup
     }
 
     /// create new key with value. If key already exist throw `HBPersistError.duplicate` error
-    func create<Object: Codable>(key: String, value: Object, expires: TimeAmount?, request: HBRequest) -> EventLoopFuture<Void> {
+    public func create<Object: Codable>(key: String, value: Object, expires: TimeAmount?, request: HBRequest) -> EventLoopFuture<Void> {
         let expiration: RedisSetCommandExpiration? = expires.map { .seconds(Int($0.nanoseconds / 1_000_000_000)) }
-        return request.redis.set(.init(key), toJSON: value, onCondition: .keyDoesNotExist, expiration: expiration).flatMapThrowing { result in
+        let redis = self.redisConnectionPoolGroup.pool(for: request.eventLoop)
+        return redis.set(.init(key), toJSON: value, onCondition: .keyDoesNotExist, expiration: expiration).flatMapThrowing { result in
             switch result {
             case .ok:
                 return
@@ -39,30 +39,43 @@ struct HBRedisPersistDriver: HBPersistDriver {
     }
 
     /// set value for key. If value already exists overwrite it
-    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount?, request: HBRequest) -> EventLoopFuture<Void> {
+    public func set<Object: Codable>(key: String, value: Object, expires: TimeAmount?, request: HBRequest) -> EventLoopFuture<Void> {
+        let redis = self.redisConnectionPoolGroup.pool(for: request.eventLoop)
         if let expires = expires {
-            return request.redis.setex(.init(key), toJSON: value, expirationInSeconds: Int(expires.nanoseconds / 1_000_000_000))
+            return redis.setex(.init(key), toJSON: value, expirationInSeconds: Int(expires.nanoseconds / 1_000_000_000))
         } else {
-            return request.redis.set(.init(key), toJSON: value)
+            return redis.set(.init(key), toJSON: value)
         }
     }
 
     /// get value for key
-    func get<Object: Codable>(key: String, as object: Object.Type, request: HBRequest) -> EventLoopFuture<Object?> {
-        request.redis.get(.init(key), asJSON: object)
+    public func get<Object: Codable>(key: String, as object: Object.Type, request: HBRequest) -> EventLoopFuture<Object?> {
+        let redis = self.redisConnectionPoolGroup.pool(for: request.eventLoop)
+        return redis.get(.init(key), asJSON: object)
     }
 
     /// remove key
-    func remove(key: String, request: HBRequest) -> EventLoopFuture<Void> {
-        request.redis.delete(.init(key))
+    public func remove(key: String, request: HBRequest) -> EventLoopFuture<Void> {
+        let redis = self.redisConnectionPoolGroup.pool(for: request.eventLoop)
+        return redis.delete(.init(key))
             .map { _ in }
     }
 }
 
 /// Factory class for persist drivers
 extension HBPersistDriverFactory {
-    /// In memory driver for persist system
+    /// Redis driver for persist system
     public static var redis: HBPersistDriverFactory {
-        .init(create: { app in HBRedisPersistDriver(application: app) })
+        .init(create: { app in HBRedisPersistDriver(redisConnectionPoolGroup: app.redis) })
+    }
+
+    /// Redis driver for persist system
+    public func redis(id: RedisConnectionPoolGroupArray.Identifier) -> HBPersistDriverFactory {
+        .init { app in
+            guard let redisConnectionPoolGroup = app.redisConnectionPools[id] else {
+                preconditionFailure("Redis Connection Pool Group id: \(id) does not exist")
+            }
+            return HBRedisPersistDriver(redisConnectionPoolGroup: redisConnectionPoolGroup)
+        }
     }
 }

--- a/Sources/HummingbirdRedis/RedisConnectionPoolGroupArray.swift
+++ b/Sources/HummingbirdRedis/RedisConnectionPoolGroupArray.swift
@@ -14,17 +14,17 @@
 
 import NIOCore
 
-public final class RedisConnectionPoolGroupArray {
-    public struct Identifier: Hashable {
-        let id: String
-        init(id: String) {
-            self.id = id
-        }
-
-        internal static var `default`: Identifier { .init(id: "_hb_default_") }
+public struct RedisConnectionPoolGroupIdentifier: Hashable {
+    let id: String
+    public init(id: String) {
+        self.id = id
     }
 
-    init(id: Identifier = .default, configuration: HBRedisConfiguration, eventLoopGroup: EventLoopGroup, logger: Logger) {
+    internal static var `default`: Self { .init(id: "_hb_default_") }
+}
+
+public final class RedisConnectionPoolGroupArray {
+    init(id: RedisConnectionPoolGroupIdentifier = .default, configuration: HBRedisConfiguration, eventLoopGroup: EventLoopGroup, logger: Logger) {
         let connectionPool = RedisConnectionPoolGroup(
             configuration: configuration,
             eventLoopGroup: eventLoopGroup,
@@ -34,7 +34,7 @@ public final class RedisConnectionPoolGroupArray {
         self.redisConnectionPools = [id: connectionPool]
     }
 
-    public func addConnectionPool(id: Identifier, configuration: HBRedisConfiguration, logger: Logger) {
+    public func addConnectionPool(id: RedisConnectionPoolGroupIdentifier, configuration: HBRedisConfiguration, logger: Logger) {
         let connectionPool = RedisConnectionPoolGroup(
             configuration: configuration,
             eventLoopGroup: self.default.eventLoopGroup,
@@ -43,7 +43,7 @@ public final class RedisConnectionPoolGroupArray {
         self.redisConnectionPools[id] = connectionPool
     }
 
-    public subscript(_ id: Identifier) -> RedisConnectionPoolGroup? {
+    public subscript(_ id: RedisConnectionPoolGroupIdentifier) -> RedisConnectionPoolGroup? {
         return self.redisConnectionPools[id]
     }
 
@@ -53,5 +53,5 @@ public final class RedisConnectionPoolGroupArray {
     }
 
     public let `default`: RedisConnectionPoolGroup
-    var redisConnectionPools: [Identifier: RedisConnectionPoolGroup]
+    var redisConnectionPools: [RedisConnectionPoolGroupIdentifier: RedisConnectionPoolGroup]
 }

--- a/Sources/HummingbirdRedis/RedisConnectionPoolGroupArray.swift
+++ b/Sources/HummingbirdRedis/RedisConnectionPoolGroupArray.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2022 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+public final class RedisConnectionPoolGroupArray {
+    public struct Identifier: Hashable {
+        let id: String
+        init(id: String) {
+            self.id = id
+        }
+
+        static var `default`: Identifier { .init(id: "default") }
+    }
+
+    init(configuration: HBRedisConfiguration, eventLoopGroup: EventLoopGroup, logger: Logger) {
+        let connectionPool = RedisConnectionPoolGroup(
+            configuration: configuration,
+            eventLoopGroup: eventLoopGroup,
+            logger: logger
+        )
+        self.default = connectionPool
+        self.redisConnectionPools = [.default: connectionPool]
+    }
+
+    public func addConnectionPool(id: Identifier, configuration: HBRedisConfiguration, logger: Logger) {
+        let connectionPool = RedisConnectionPoolGroup(
+            configuration: configuration,
+            eventLoopGroup: self.default.eventLoopGroup,
+            logger: logger
+        )
+        self.redisConnectionPools[id] = connectionPool
+    }
+
+    public subscript(_ id: Identifier) -> RedisConnectionPoolGroup? {
+        return self.redisConnectionPools[id]
+    }
+
+    func closePools() -> EventLoopFuture<Void> {
+        let closeFutures = self.redisConnectionPools.map { $0.value.closePools() }
+        return EventLoopFuture.andAllComplete(closeFutures, on: self.default.eventLoopGroup.any())
+    }
+
+    public let `default`: RedisConnectionPoolGroup
+    var redisConnectionPools: [Identifier: RedisConnectionPoolGroup]
+}

--- a/Sources/HummingbirdRedis/RedisConnectionPoolGroupArray.swift
+++ b/Sources/HummingbirdRedis/RedisConnectionPoolGroupArray.swift
@@ -14,8 +14,13 @@
 
 import NIOCore
 
-public struct RedisConnectionPoolGroupIdentifier: Hashable {
+public struct RedisConnectionPoolGroupIdentifier: Hashable, ExpressibleByStringLiteral {
     let id: String
+
+    public init(stringLiteral: String) {
+        self.id = stringLiteral
+    }
+
     public init(id: String) {
         self.id = id
     }

--- a/Sources/HummingbirdRedis/RedisConnectionPoolGroupArray.swift
+++ b/Sources/HummingbirdRedis/RedisConnectionPoolGroupArray.swift
@@ -21,17 +21,17 @@ public final class RedisConnectionPoolGroupArray {
             self.id = id
         }
 
-        static var `default`: Identifier { .init(id: "default") }
+        internal static var `default`: Identifier { .init(id: "_hb_default_") }
     }
 
-    init(configuration: HBRedisConfiguration, eventLoopGroup: EventLoopGroup, logger: Logger) {
+    init(id: Identifier = .default, configuration: HBRedisConfiguration, eventLoopGroup: EventLoopGroup, logger: Logger) {
         let connectionPool = RedisConnectionPoolGroup(
             configuration: configuration,
             eventLoopGroup: eventLoopGroup,
             logger: logger
         )
         self.default = connectionPool
-        self.redisConnectionPools = [.default: connectionPool]
+        self.redisConnectionPools = [id: connectionPool]
     }
 
     public func addConnectionPool(id: Identifier, configuration: HBRedisConfiguration, logger: Logger) {

--- a/Sources/HummingbirdRedis/Request+Redis.swift
+++ b/Sources/HummingbirdRedis/Request+Redis.swift
@@ -20,7 +20,7 @@ extension HBRequest {
         .init(eventLoop: self.eventLoop, logger: self.logger, connectionPoolGroup: self.application.redis)
     }
 
-    public func redis(id: RedisConnectionPoolGroupArray.Identifier) -> Redis {
+    public func redis(id: RedisConnectionPoolGroupIdentifier) -> Redis {
         guard let redisConnectionPoolGroup = self.application.redis(id: id) else {
             preconditionFailure("Redis Connection Pool Group id: '\(id)' does not exist")
         }

--- a/Sources/HummingbirdRedis/Request+Redis.swift
+++ b/Sources/HummingbirdRedis/Request+Redis.swift
@@ -17,29 +17,34 @@ import RediStack
 
 extension HBRequest {
     public var redis: Redis {
-        .init(request: self)
+        .init(eventLoop: self.eventLoop, logger: self.logger, connectionPoolGroup: self.application.redis)
+    }
+
+    public func redis(id: RedisConnectionPoolGroupArray.Identifier) -> Redis {
+        guard let redisConnectionPoolGroup = self.application.redis(id: id) else {
+            preconditionFailure("Redis Connection Pool Group id: '\(id)' does not exist")
+        }
+        return .init(eventLoop: self.eventLoop, logger: self.logger, connectionPoolGroup: redisConnectionPoolGroup)
     }
 
     public struct Redis {
-        let request: HBRequest
+        public let eventLoop: EventLoop
+        let logger: Logger
+        let connectionPoolGroup: RedisConnectionPoolGroup
     }
 }
 
 extension HBRequest.Redis: RedisClient {
-    public var eventLoop: EventLoop {
-        self.request.eventLoop
-    }
-
     public func logging(to logger: Logger) -> RedisClient {
-        self.request.application.redis
+        self.connectionPoolGroup
             .pool(for: self.eventLoop)
             .logging(to: logger)
     }
 
     public func send(command: String, with arguments: [RESPValue]) -> EventLoopFuture<RESPValue> {
-        self.request.application.redis
+        self.connectionPoolGroup
             .pool(for: self.eventLoop)
-            .logging(to: self.request.logger)
+            .logging(to: self.logger)
             .send(command: command, with: arguments)
     }
 
@@ -49,16 +54,16 @@ extension HBRequest.Redis: RedisClient {
         onSubscribe subscribeHandler: RedisSubscriptionChangeHandler?,
         onUnsubscribe unsubscribeHandler: RedisSubscriptionChangeHandler?
     ) -> EventLoopFuture<Void> {
-        return self.request.application.redis
+        return self.connectionPoolGroup
             .pubsubClient
-            .logging(to: self.request.logger)
+            .logging(to: self.logger)
             .subscribe(to: channels, messageReceiver: receiver, onSubscribe: subscribeHandler, onUnsubscribe: unsubscribeHandler)
     }
 
     public func unsubscribe(from channels: [RedisChannelName]) -> EventLoopFuture<Void> {
-        return self.request.application.redis
+        return self.connectionPoolGroup
             .pubsubClient
-            .logging(to: self.request.logger)
+            .logging(to: self.logger)
             .unsubscribe(from: channels)
     }
 
@@ -68,16 +73,16 @@ extension HBRequest.Redis: RedisClient {
         onSubscribe subscribeHandler: RedisSubscriptionChangeHandler?,
         onUnsubscribe unsubscribeHandler: RedisSubscriptionChangeHandler?
     ) -> EventLoopFuture<Void> {
-        return self.request.application.redis
+        return self.connectionPoolGroup
             .pubsubClient
-            .logging(to: self.request.logger)
+            .logging(to: self.logger)
             .psubscribe(to: patterns, messageReceiver: receiver, onSubscribe: subscribeHandler, onUnsubscribe: unsubscribeHandler)
     }
 
     public func punsubscribe(from patterns: [String]) -> EventLoopFuture<Void> {
-        return self.request.application.redis
+        return self.connectionPoolGroup
             .pubsubClient
-            .logging(to: self.request.logger)
+            .logging(to: self.logger)
             .punsubscribe(from: patterns)
     }
 }

--- a/Tests/HummingbirdRedisTests/RedisTests.swift
+++ b/Tests/HummingbirdRedisTests/RedisTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Hummingbird
-@testable import HummingbirdRedis
+import HummingbirdRedis
 import HummingbirdXCT
 import NIOPosix
 import XCTest
@@ -89,7 +89,7 @@ final class HummingbirdRedisTests: XCTestCase {
     }
 }
 
-extension RedisConnectionPoolGroupArray.Identifier {
+extension RedisConnectionPoolGroupIdentifier {
     static var test: Self {
         .init(id: "test")
     }

--- a/Tests/HummingbirdRedisTests/RedisTests.swift
+++ b/Tests/HummingbirdRedisTests/RedisTests.swift
@@ -55,8 +55,8 @@ final class HummingbirdRedisTests: XCTestCase {
             try await request.redis(id: .test).set("Test", to: value).get()
             return .ok
         }
-        app.router.get("test") { request -> String? in
-            try await request.redis(id: .test).get("Test").get().string
+        app.router.get("test") { request in
+            request.redis(id: .test).get("Test").map(\.string)
         }
         try app.XCTStart()
         defer { app.XCTStop() }


### PR DESCRIPTION
Multiple redis databases work as follows
```swift
extension RedisConnectionPoolGroupIdentifier {
    static var myRedis: Self { .init(id: "my-redis") }
}
application.addRedis(
    id: .myRedis, 
    configuration: .init(...)
)
application.router.get("redis") { request in
    request.redis(id: .myRedis).get("Test").map(\.string)
}
```
You can still use the `request.redis` property as well. It will use the first redis database you added to the application.

You can now also run RedisConnectionPoolGroup separate from the HBApplication
```swift
struct MyRedisController {
    let redisConnectionPoolGroup: RedisConnectionPoolGroup

    /// Return RedisConnectionPool for request
    func redis(for request: HBRequest) -> RedisConnectionPool {
        redisConnectionPoolGroup.pool(for: request.eventLoop)
    }
    /// My route handler
    func myRoute(request: HBRequest) { request in
        redis(for: request).get("Test").map(\.string)
    }
}
```
