### PR TITLE
persist `set` should not update expires if key already exist and expire is nil

### DIFF
--- a/Tests/HummingbirdRedisTests/PersistTests.swift
+++ b/Tests/HummingbirdRedisTests/PersistTests.swift
@@ -195,12 +195,12 @@ final class PersistTests: XCTestCase {
         try await app.test(.router) { client in
 
             let tag = UUID().uuidString
-            try await client.execute(uri: "/persist/\(tag)/0", method: .put, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
+            try await client.execute(uri: "/persist/\(tag)/0", method: .put, body: ByteBuffer(string: "ThisIsTest1")) { _ in }
             try await Task.sleep(nanoseconds: 1_000_000_000)
             try await client.execute(uri: "/persist/\(tag)", method: .get) { response in
                 XCTAssertEqual(response.status, .noContent)
             }
-            try await client.execute(uri: "/persist/\(tag)/10", method: .put, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { response in
+            try await client.execute(uri: "/persist/\(tag)/10", method: .put, body: ByteBuffer(string: "ThisIsTest1")) { response in
                 XCTAssertEqual(response.status, .ok)
             }
             try await client.execute(uri: "/persist/\(tag)", method: .get) { response in


### PR DESCRIPTION
Also remove a bunch of support functions for deprecated redis commands
And made the JSON support functions async