### PR TITLE
Persist invalid conversion

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "HummingbirdRedis", targets: ["HummingbirdRedis"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.5.0"),
         .package(url: "https://github.com/swift-server/RediStack.git", from: "1.4.0"),
     ],
     targets: [

--- a/Sources/HummingbirdRedis/Persist+Redis.swift
+++ b/Sources/HummingbirdRedis/Persist+Redis.swift
@@ -57,7 +57,11 @@ public struct RedisPersistDriver: PersistDriver {
 
     /// get value for key
     public func get<Object: Codable>(key: String, as object: Object.Type) async throws -> Object? {
-        try await self.redisConnectionPool.get(.init(key), asJSON: object)
+        do {
+            return try await self.redisConnectionPool.get(.init(key), asJSON: object)
+        } catch is DecodingError {
+            throw PersistError.invalidConversion
+        }
     }
 
     /// remove key


### PR DESCRIPTION
Throw `PersistError.invalidConversion` when failing to convert in `RedisPersistDriver.get(key:as:)`